### PR TITLE
敵が画面外に出たときに敵のUIを非表示にする処理を追加

### DIFF
--- a/Game/Game/Monster/Monster.cpp
+++ b/Game/Game/Monster/Monster.cpp
@@ -42,8 +42,7 @@ namespace nsAWA {
 			m_enemyBattleStatusUI->SetUIEnemyStatus(
 				m_status.GetHP(), m_status.GetMaxHP(), 0.0f
 			);
-			// nsGraphics::CCamera::CalcScreenPositionFromWorldPosition()
-			m_enemyBattleStatusUI->SetUIEnemyPosition(MainCamera()->CalcScreenPositionFromWorldPosition(m_position));
+			m_enemyBattleStatusUI->SetUIEnemyPosition(m_position);
 			
 
 

--- a/Game/Game/UI/Battle/Enemy/EnemyBattleStatusUI.cpp
+++ b/Game/Game/UI/Battle/Enemy/EnemyBattleStatusUI.cpp
@@ -84,21 +84,56 @@ namespace nsAWA
             //m_enemyBreakUI->SetUIEnemyBreakStatus(breakBar);
         }
 
-        void CEnemyBattleStatusUI::SetUIEnemyPosition(const CVector2& position)
+        void CEnemyBattleStatusUI::SetUIEnemyPosition(const CVector3& position)
         {
+            if (true == CheckDrawUI(position)) {
+                m_spriteEnemyStatusBase->SetDrawingFlag(true);
+            }
+            else {
+                m_spriteEnemyStatusBase->SetDrawingFlag(false);
+
+                return;
+            }
+
+            CVector3 targetPosition = position;
+            CVector2 uiPosition = MainCamera()->CalcScreenPositionFromWorldPosition(targetPosition);
+
+
+
             // これだと、全部一か所にまとまるので、
             // 補正値を追加で入れること
             m_spriteEnemyStatusBase->SetPosition(
                 {
-                    position.x + m_initialPosition.x,
-                    position.y + m_kUIPositionCorrectionAmountY + m_initialPosition.y
+                    uiPosition.x + m_initialPosition.x,
+                    uiPosition.y + m_kUIPositionCorrectionAmountY + m_initialPosition.y
                 }
             );
 
-            m_setUIEnemyPosition = { position.x,position.y + m_kUIPositionCorrectionAmountY };
+            m_setUIEnemyPosition = { uiPosition.x,uiPosition.y + m_kUIPositionCorrectionAmountY };
 
             m_enemyHPUI->SetUIPosition(m_setUIEnemyPosition);
             //m_enemyBreakUI->SetUIPosition(m_setUIEnemyPosition);
+        }
+
+        const bool CEnemyBattleStatusUI::CheckDrawUI(const CVector3& targetPosition)
+        {
+            CVector3 normalizeCameraForwardDirection = MainCamera()->GetForeardDirection();
+            CVector3 normalizeTargetPosition = targetPosition - MainCamera()->GetPosition();
+
+            normalizeCameraForwardDirection.Normalize();
+            normalizeTargetPosition.Normalize();
+
+            float resultFieldOfView = 
+                nsMath::RadToDeg(std::acos(nsMath::Dot(normalizeCameraForwardDirection, normalizeTargetPosition)));
+
+            // 視野に入っているか計算
+            if (resultFieldOfView <= 90.0f) {
+                // 見つけたので成功
+                return true;
+            }
+
+            // 失敗
+            return false;
         }
     }
 }

--- a/Game/Game/UI/Battle/Enemy/EnemyBattleStatusUI.h
+++ b/Game/Game/UI/Battle/Enemy/EnemyBattleStatusUI.h
@@ -37,7 +37,9 @@ namespace nsAWA
              * @brief UI‚ÌˆÊ’u‚ğæ“¾
              * @param position “G‚ÌˆÊ’u
             */
-            void SetUIEnemyPosition(const CVector2& position);
+            void SetUIEnemyPosition(const CVector3& position);
+
+            const bool CheckDrawUI(const CVector3& targetPosition);
 
 
         private: // constant data member
@@ -61,6 +63,7 @@ namespace nsAWA
             CVector2 m_initialPosition = CVector2::Zero(); // UI‚Ì‰ŠúˆÊ’u
 
             CVector2 m_setUIEnemyPosition = CVector2::Zero();
+
         };
     }
 }


### PR DESCRIPTION
※土台部分だけ非表示で、残りは画面外で位置の更新が止まってる状態になってると思う